### PR TITLE
feat: Increase key length and add mysql collation for index key column

### DIFF
--- a/amundsen_rds/models/application.py
+++ b/amundsen_rds/models/application.py
@@ -4,7 +4,8 @@
 from sqlalchemy import BigInteger, Column, ForeignKey, String, Text
 
 from amundsen_rds.models.base import (
-    KEY_LEN, NAME_LEN, PUBLISHED_TAG_LEN, URL_LEN, Base
+    INDEX_KEY_COLLATION_ARGS, KEY_LEN, NAME_LEN, PUBLISHED_TAG_LEN, URL_LEN,
+    Base
 )
 
 
@@ -14,7 +15,7 @@ class Application(Base):
     """
     __tablename__ = 'application'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     application_url = Column(String(URL_LEN), nullable=False)
     name = Column(String(NAME_LEN), nullable=False)
     id = Column(String(128), nullable=False)
@@ -29,7 +30,11 @@ class ApplicationTable(Base):
     """
     __tablename__ = 'application_table'
 
-    rk = Column(String(KEY_LEN), ForeignKey('table_metadata.rk', ondelete='cascade'), primary_key=True)
-    application_rk = Column(String(KEY_LEN), ForeignKey('application.rk', ondelete='cascade'), nullable=False)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                ForeignKey('table_metadata.rk', ondelete='cascade'),
+                primary_key=True)
+    application_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                            ForeignKey('application.rk', ondelete='cascade'),
+                            nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)

--- a/amundsen_rds/models/badge.py
+++ b/amundsen_rds/models/badge.py
@@ -3,7 +3,9 @@
 
 from sqlalchemy import BigInteger, Column, String
 
-from amundsen_rds.models.base import KEY_LEN, PUBLISHED_TAG_LEN, Base
+from amundsen_rds.models.base import (
+    INDEX_KEY_COLLATION_ARGS, PUBLISHED_TAG_LEN, Base
+)
 
 
 class Badge(Base):
@@ -12,7 +14,7 @@ class Badge(Base):
     """
     __tablename__ = 'badge'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(128, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     category = Column(String(32), nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN))
     publisher_last_updated_epoch_ms = Column(BigInteger)

--- a/amundsen_rds/models/base.py
+++ b/amundsen_rds/models/base.py
@@ -11,3 +11,7 @@ KEY_LEN = 1024
 NAME_LEN = 256
 URL_LEN = 2048
 PUBLISHED_TAG_LEN = 128
+
+INDEX_KEY_COLLATION_ARGS = {
+    'collation': 'latin1_general_cs'
+}

--- a/amundsen_rds/models/base.py
+++ b/amundsen_rds/models/base.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.declarative import declarative_base
 metadata = MetaData()
 Base = declarative_base(metadata=metadata)
 
-KEY_LEN = 512
-NAME_LEN = 128
+KEY_LEN = 1024
+NAME_LEN = 256
 URL_LEN = 2048
 PUBLISHED_TAG_LEN = 128

--- a/amundsen_rds/models/cluster.py
+++ b/amundsen_rds/models/cluster.py
@@ -4,7 +4,9 @@
 from sqlalchemy import BigInteger, Column, ForeignKey, String
 from sqlalchemy.orm import relationship
 
-from amundsen_rds.models.base import KEY_LEN, NAME_LEN, PUBLISHED_TAG_LEN, Base
+from amundsen_rds.models.base import (
+    INDEX_KEY_COLLATION_ARGS, KEY_LEN, NAME_LEN, PUBLISHED_TAG_LEN, Base
+)
 
 
 class Cluster(Base):
@@ -13,9 +15,11 @@ class Cluster(Base):
     """
     __tablename__ = 'cluster_metadata'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     name = Column(String(NAME_LEN), nullable=False)
-    database_rk = Column(String(KEY_LEN), ForeignKey('database_metadata.rk', ondelete='cascade'), nullable=False)
+    database_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                         ForeignKey('database_metadata.rk', ondelete='cascade'),
+                         nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
 

--- a/amundsen_rds/models/column.py
+++ b/amundsen_rds/models/column.py
@@ -4,7 +4,9 @@
 from sqlalchemy import BigInteger, Column, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import relationship
 
-from amundsen_rds.models.base import KEY_LEN, NAME_LEN, PUBLISHED_TAG_LEN, Base
+from amundsen_rds.models.base import (
+    INDEX_KEY_COLLATION_ARGS, KEY_LEN, NAME_LEN, PUBLISHED_TAG_LEN, Base
+)
 
 
 class TableColumn(Base):
@@ -13,11 +15,13 @@ class TableColumn(Base):
     """
     __tablename__ = 'column_metadata'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
-    name = Column(String(NAME_LEN), nullable=False)
+    rk = Column(String(1536, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
+    name = Column(String(768), nullable=False)
     type = Column(String(32), nullable=False)
     sort_order = Column(Integer, nullable=False)
-    table_rk = Column(String(KEY_LEN), ForeignKey('table_metadata.rk', ondelete='cascade'), nullable=False)
+    table_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                      ForeignKey('table_metadata.rk', ondelete='cascade'),
+                      nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
 
@@ -32,10 +36,12 @@ class ColumnDescription(Base):
     """
     __tablename__ = 'column_description'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(1536, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     description_source = Column(String(32), nullable=False)
     description = Column(Text)
-    column_rk = Column(String(KEY_LEN), ForeignKey('column_metadata.rk', ondelete='cascade'), nullable=False)
+    column_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                       ForeignKey('column_metadata.rk', ondelete='cascade'),
+                       nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN))
     publisher_last_updated_epoch_ms = Column(BigInteger)
 
@@ -46,8 +52,12 @@ class ColumnBadge(Base):
     """
     __tablename__ = 'column_badge'
 
-    column_rk = Column(String(KEY_LEN), ForeignKey('column_metadata.rk', ondelete='cascade'), primary_key=True)
-    badge_rk = Column(String(KEY_LEN), ForeignKey('badge.rk', ondelete='cascade'), primary_key=True)
+    column_rk = Column(String(1536, **INDEX_KEY_COLLATION_ARGS),
+                       ForeignKey('column_metadata.rk', ondelete='cascade'),
+                       primary_key=True)
+    badge_rk = Column(String(128, **INDEX_KEY_COLLATION_ARGS),
+                      ForeignKey('badge.rk', ondelete='cascade'),
+                      primary_key=True)
     published_tag = Column(String(PUBLISHED_TAG_LEN))
     publisher_last_updated_epoch_ms = Column(BigInteger)
 
@@ -58,11 +68,13 @@ class ColumnStat(Base):
     """
     __tablename__ = 'column_stat'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(1536, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     stat_name = Column(String(NAME_LEN), nullable=False)
     stat_val = Column(String(128), nullable=False)
     start_epoch = Column(String(16), nullable=False)
     end_epoch = Column(String(16), nullable=False)
-    column_rk = Column(String(KEY_LEN), ForeignKey('column_metadata.rk', ondelete='cascade'), nullable=False)
+    column_rk = Column(String(1536, **INDEX_KEY_COLLATION_ARGS),
+                       ForeignKey('column_metadata.rk', ondelete='cascade'),
+                       nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)

--- a/amundsen_rds/models/dashboard.py
+++ b/amundsen_rds/models/dashboard.py
@@ -5,7 +5,8 @@ from sqlalchemy import BigInteger, Column, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import relationship
 
 from amundsen_rds.models.base import (
-    KEY_LEN, NAME_LEN, PUBLISHED_TAG_LEN, URL_LEN, Base
+    INDEX_KEY_COLLATION_ARGS, KEY_LEN, NAME_LEN, PUBLISHED_TAG_LEN, URL_LEN,
+    Base
 )
 
 
@@ -15,11 +16,13 @@ class Dashboard(Base):
     """
     __tablename__ = 'dashboard'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     name = Column(String(NAME_LEN), nullable=False)
     created_timestamp = Column(Integer)
     dashboard_url = Column(String(URL_LEN))
-    dashboard_group_rk = Column(String(KEY_LEN), ForeignKey('dashboard_group.rk', ondelete='cascade'), nullable=False)
+    dashboard_group_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                                ForeignKey('dashboard_group.rk', ondelete='cascade'),
+                                nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
 
@@ -43,9 +46,11 @@ class DashboardDescription(Base):
     """
     __tablename__ = 'dashboard_description'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     description = Column(Text)
-    dashboard_rk = Column(String(KEY_LEN), ForeignKey('dashboard.rk', ondelete='cascade'), nullable=False)
+    dashboard_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                          ForeignKey('dashboard.rk', ondelete='cascade'),
+                          nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN))
     publisher_last_updated_epoch_ms = Column(BigInteger)
 
@@ -56,8 +61,12 @@ class DashboardBadge(Base):
     """
     __tablename__ = 'dashboard_badge'
 
-    dashboard_rk = Column(String(KEY_LEN), ForeignKey('dashboard.rk', ondelete='cascade'), primary_key=True)
-    badge_rk = Column(String(KEY_LEN), ForeignKey('badge.rk', ondelete='cascade'), primary_key=True)
+    dashboard_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                          ForeignKey('dashboard.rk', ondelete='cascade'),
+                          primary_key=True)
+    badge_rk = Column(String(128, **INDEX_KEY_COLLATION_ARGS),
+                      ForeignKey('badge.rk', ondelete='cascade'),
+                      primary_key=True)
     published_tag = Column(String(PUBLISHED_TAG_LEN))
     publisher_last_updated_epoch_ms = Column(BigInteger)
 
@@ -68,8 +77,12 @@ class DashboardUsage(Base):
     """
     __tablename__ = 'dashboard_usage'
 
-    dashboard_rk = Column(String(KEY_LEN), ForeignKey('dashboard.rk', ondelete='cascade'), primary_key=True)
-    user_rk = Column(String(KEY_LEN), ForeignKey('users.rk', ondelete='cascade'), primary_key=True)
+    dashboard_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                          ForeignKey('dashboard.rk', ondelete='cascade'),
+                          primary_key=True)
+    user_rk = Column(String(320, **INDEX_KEY_COLLATION_ARGS),
+                     ForeignKey('users.rk', ondelete='cascade'),
+                     primary_key=True)
     read_count = Column(Integer, nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
@@ -81,8 +94,12 @@ class DashboardOwner(Base):
     """
     __tablename__ = 'dashboard_owner'
 
-    dashboard_rk = Column(String(KEY_LEN), ForeignKey('dashboard.rk', ondelete='cascade'), primary_key=True)
-    user_rk = Column(String(KEY_LEN), ForeignKey('users.rk', ondelete='cascade'), primary_key=True)
+    dashboard_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                          ForeignKey('dashboard.rk', ondelete='cascade'),
+                          primary_key=True)
+    user_rk = Column(String(320, **INDEX_KEY_COLLATION_ARGS),
+                     ForeignKey('users.rk', ondelete='cascade'),
+                     primary_key=True)
     published_tag = Column(String(PUBLISHED_TAG_LEN))
     publisher_last_updated_epoch_ms = Column(BigInteger)
 
@@ -93,8 +110,12 @@ class DashboardFollower(Base):
     """
     __tablename__ = 'dashboard_follower'
 
-    dashboard_rk = Column(String(KEY_LEN), ForeignKey('dashboard.rk', ondelete='cascade'), primary_key=True)
-    user_rk = Column(String(KEY_LEN), ForeignKey('users.rk', ondelete='cascade'), primary_key=True)
+    dashboard_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                          ForeignKey('dashboard.rk', ondelete='cascade'),
+                          primary_key=True)
+    user_rk = Column(String(320, **INDEX_KEY_COLLATION_ARGS),
+                     ForeignKey('users.rk', ondelete='cascade'),
+                     primary_key=True)
     published_tag = Column(String(PUBLISHED_TAG_LEN))
     publisher_last_updated_epoch_ms = Column(BigInteger)
 
@@ -105,8 +126,12 @@ class DashboardTable(Base):
     """
     __tablename__ = 'dashboard_table'
 
-    dashboard_rk = Column(String(KEY_LEN), ForeignKey('dashboard.rk', ondelete='cascade'), primary_key=True)
-    table_rk = Column(String(KEY_LEN), ForeignKey('table_metadata.rk', ondelete='cascade'), primary_key=True)
+    dashboard_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                          ForeignKey('dashboard.rk', ondelete='cascade'),
+                          primary_key=True)
+    table_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                      ForeignKey('table_metadata.rk', ondelete='cascade'),
+                      primary_key=True)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
 
@@ -117,8 +142,12 @@ class DashboardTag(Base):
     """
     __tablename__ = 'dashboard_tag'
 
-    dashboard_rk = Column(String(KEY_LEN), ForeignKey('dashboard.rk', ondelete='cascade'), primary_key=True)
-    tag_rk = Column(String(KEY_LEN), ForeignKey('tag.rk', ondelete='cascade'), primary_key=True)
+    dashboard_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                          ForeignKey('dashboard.rk', ondelete='cascade'),
+                          primary_key=True)
+    tag_rk = Column(String(128, **INDEX_KEY_COLLATION_ARGS),
+                    ForeignKey('tag.rk', ondelete='cascade'),
+                    primary_key=True)
     published_tag = Column(String(PUBLISHED_TAG_LEN))
     publisher_last_updated_epoch_ms = Column(BigInteger)
 
@@ -129,10 +158,12 @@ class DashboardTimestamp(Base):
     """
     __tablename__ = 'dashboard_timestamp'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     timestamp = Column(Integer, nullable=False)
     name = Column(String(NAME_LEN), nullable=False)
-    dashboard_rk = Column(String(KEY_LEN), ForeignKey('dashboard.rk', ondelete='cascade'), nullable=False)
+    dashboard_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                          ForeignKey('dashboard.rk', ondelete='cascade'),
+                          nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
 
@@ -143,7 +174,7 @@ class DashboardCluster(Base):
     """
     __tablename__ = 'dashboard_cluster'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     name = Column(String(NAME_LEN), nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
@@ -155,10 +186,12 @@ class DashboardGroup(Base):
     """
     __tablename__ = 'dashboard_group'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     name = Column(String(NAME_LEN), nullable=False)
     dashboard_group_url = Column(String(URL_LEN))
-    cluster_rk = Column(String(KEY_LEN), ForeignKey('dashboard_cluster.rk', ondelete='cascade'), nullable=False)
+    cluster_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                        ForeignKey('dashboard_cluster.rk', ondelete='cascade'),
+                        nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
 
@@ -172,9 +205,11 @@ class DashboardGroupDescription(Base):
     """
     __tablename__ = 'dashboard_group_description'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     description = Column(Text)
-    dashboard_group_rk = Column(String(KEY_LEN), ForeignKey('dashboard_group.rk', ondelete='cascade'), nullable=False)
+    dashboard_group_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                                ForeignKey('dashboard_group.rk', ondelete='cascade'),
+                                nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
 
@@ -185,10 +220,12 @@ class DashboardExecution(Base):
     """
     __tablename__ = 'dashboard_execution'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     timestamp = Column(Integer, nullable=False)
     state = Column(String(16), nullable=False)
-    dashboard_rk = Column(String(KEY_LEN), ForeignKey('dashboard.rk', ondelete='cascade'), nullable=False)
+    dashboard_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                          ForeignKey('dashboard.rk', ondelete='cascade'),
+                          nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
 
@@ -199,12 +236,14 @@ class DashboardQuery(Base):
     """
     __tablename__ = 'dashboard_query'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     id = Column(String(32), nullable=False)
     name = Column(String(NAME_LEN), nullable=False)
     url = Column(String(URL_LEN))
     query_text = Column(Text)
-    dashboard_rk = Column(String(KEY_LEN), ForeignKey('dashboard.rk', ondelete='cascade'), nullable=False)
+    dashboard_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                          ForeignKey('dashboard.rk', ondelete='cascade'),
+                          nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
 
@@ -217,11 +256,13 @@ class DashboardChart(Base):
     """
     __tablename__ = 'dashboard_chart'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     id = Column(String(32), nullable=False)
     name = Column(String(NAME_LEN))
     type = Column(String(32))
     url = Column(String(URL_LEN))
-    query_rk = Column(String(KEY_LEN), ForeignKey('dashboard_query.rk', ondelete='cascade'), nullable=False)
+    query_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                      ForeignKey('dashboard_query.rk', ondelete='cascade'),
+                      nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)

--- a/amundsen_rds/models/database.py
+++ b/amundsen_rds/models/database.py
@@ -3,7 +3,9 @@
 
 from sqlalchemy import BigInteger, Column, String
 
-from amundsen_rds.models.base import KEY_LEN, NAME_LEN, PUBLISHED_TAG_LEN, Base
+from amundsen_rds.models.base import (
+    INDEX_KEY_COLLATION_ARGS, KEY_LEN, NAME_LEN, PUBLISHED_TAG_LEN, Base
+)
 
 
 class Database(Base):
@@ -12,7 +14,7 @@ class Database(Base):
     """
     __tablename__ = 'database_metadata'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     name = Column(String(NAME_LEN), nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)

--- a/amundsen_rds/models/schema.py
+++ b/amundsen_rds/models/schema.py
@@ -4,7 +4,9 @@
 from sqlalchemy import BigInteger, Column, ForeignKey, String, Text
 from sqlalchemy.orm import relationship
 
-from amundsen_rds.models.base import KEY_LEN, NAME_LEN, PUBLISHED_TAG_LEN, Base
+from amundsen_rds.models.base import (
+    INDEX_KEY_COLLATION_ARGS, KEY_LEN, NAME_LEN, PUBLISHED_TAG_LEN, Base
+)
 
 
 class Schema(Base):
@@ -13,9 +15,11 @@ class Schema(Base):
     """
     __tablename__ = 'schema_metadata'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     name = Column(String(NAME_LEN), nullable=False)
-    cluster_rk = Column(String(KEY_LEN), ForeignKey('cluster_metadata.rk', ondelete='cascade'), nullable=False)
+    cluster_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                        ForeignKey('cluster_metadata.rk', ondelete='cascade'),
+                        nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
 
@@ -29,9 +33,11 @@ class SchemaDescription(Base):
     """
     __tablename__ = 'schema_description'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     description_source = Column(String(32), nullable=False)
     description = Column(Text)
-    schema_rk = Column(String(KEY_LEN), ForeignKey('schema_metadata.rk', ondelete='cascade'), nullable=False)
+    schema_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                       ForeignKey('schema_metadata.rk', ondelete='cascade'),
+                       nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)

--- a/amundsen_rds/models/table.py
+++ b/amundsen_rds/models/table.py
@@ -7,7 +7,8 @@ from sqlalchemy import (
 from sqlalchemy.orm import relationship
 
 from amundsen_rds.models.base import (
-    KEY_LEN, NAME_LEN, PUBLISHED_TAG_LEN, URL_LEN, Base
+    INDEX_KEY_COLLATION_ARGS, KEY_LEN, NAME_LEN, PUBLISHED_TAG_LEN, URL_LEN,
+    Base
 )
 
 
@@ -17,10 +18,12 @@ class Table(Base):
     """
     __tablename__ = 'table_metadata'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     name = Column(String(NAME_LEN), nullable=False)
     is_view = Column(Boolean, nullable=False)
-    schema_rk = Column(String(KEY_LEN), ForeignKey('schema_metadata.rk', ondelete='cascade'), nullable=False)
+    schema_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                       ForeignKey('schema_metadata.rk', ondelete='cascade'),
+                       nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger)
 
@@ -46,10 +49,12 @@ class TableDescription(Base):
     """
     __tablename__ = 'table_description'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     description_source = Column(String(32), nullable=False)
     description = Column(Text)
-    table_rk = Column(String(KEY_LEN), ForeignKey('table_metadata.rk', ondelete='cascade'), nullable=False)
+    table_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                      ForeignKey('table_metadata.rk', ondelete='cascade'),
+                      nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN))
     publisher_last_updated_epoch_ms = Column(BigInteger)
 
@@ -60,10 +65,12 @@ class TableProgrammaticDescription(Base):
     """
     __tablename__ = 'table_programmatic_description'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     description_source = Column(String(32), nullable=False)
     description = Column(Text)
-    table_rk = Column(String(KEY_LEN), ForeignKey('table_metadata.rk', ondelete='cascade'), nullable=False)
+    table_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                      ForeignKey('table_metadata.rk', ondelete='cascade'),
+                      nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
 
@@ -74,8 +81,12 @@ class TableUsage(Base):
     """
     __tablename__ = 'table_usage'
 
-    table_rk = Column(String(KEY_LEN), ForeignKey('table_metadata.rk', ondelete='cascade'), primary_key=True)
-    user_rk = Column(String(KEY_LEN), ForeignKey('users.rk', ondelete='cascade'), primary_key=True)
+    table_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                      ForeignKey('table_metadata.rk', ondelete='cascade'),
+                      primary_key=True)
+    user_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                     ForeignKey('users.rk', ondelete='cascade'),
+                     primary_key=True)
     read_count = Column(Integer, nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
@@ -87,8 +98,12 @@ class TableOwner(Base):
     """
     __tablename__ = 'table_owner'
 
-    table_rk = Column(String(KEY_LEN), ForeignKey('table_metadata.rk', ondelete='cascade'), primary_key=True)
-    user_rk = Column(String(KEY_LEN), ForeignKey('users.rk', ondelete='cascade'), primary_key=True)
+    table_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                      ForeignKey('table_metadata.rk', ondelete='cascade'),
+                      primary_key=True)
+    user_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                     ForeignKey('users.rk', ondelete='cascade'),
+                     primary_key=True)
     published_tag = Column(String(PUBLISHED_TAG_LEN))
     publisher_last_updated_epoch_ms = Column(BigInteger)
 
@@ -99,8 +114,12 @@ class TableFollower(Base):
     """
     __tablename__ = 'table_follower'
 
-    table_rk = Column(String(KEY_LEN), ForeignKey('table_metadata.rk', ondelete='cascade'), primary_key=True)
-    user_rk = Column(String(KEY_LEN), ForeignKey('users.rk', ondelete='cascade'), primary_key=True)
+    table_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                      ForeignKey('table_metadata.rk', ondelete='cascade'),
+                      primary_key=True)
+    user_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                     ForeignKey('users.rk', ondelete='cascade'),
+                     primary_key=True)
     published_tag = Column(String(PUBLISHED_TAG_LEN))
     publisher_last_updated_epoch_ms = Column(BigInteger)
 
@@ -111,8 +130,12 @@ class TableTag(Base):
     """
     __tablename__ = 'table_tag'
 
-    table_rk = Column(String(KEY_LEN), ForeignKey('table_metadata.rk', ondelete='cascade'), primary_key=True)
-    tag_rk = Column(String(KEY_LEN), ForeignKey('tag.rk', ondelete='cascade'), primary_key=True)
+    table_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                      ForeignKey('table_metadata.rk', ondelete='cascade'),
+                      primary_key=True)
+    tag_rk = Column(String(128, **INDEX_KEY_COLLATION_ARGS),
+                    ForeignKey('tag.rk', ondelete='cascade'),
+                    primary_key=True)
     published_tag = Column(String(PUBLISHED_TAG_LEN))
     publisher_last_updated_epoch_ms = Column(BigInteger)
 
@@ -123,8 +146,12 @@ class TableBadge(Base):
     """
     __tablename__ = 'table_badge'
 
-    table_rk = Column(String(KEY_LEN), ForeignKey('table_metadata.rk', ondelete='cascade'), primary_key=True)
-    badge_rk = Column(String(KEY_LEN), ForeignKey('badge.rk', ondelete='cascade'), primary_key=True)
+    table_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                      ForeignKey('table_metadata.rk', ondelete='cascade'),
+                      primary_key=True)
+    badge_rk = Column(String(128, **INDEX_KEY_COLLATION_ARGS),
+                      ForeignKey('badge.rk', ondelete='cascade'),
+                      primary_key=True)
     published_tag = Column(String(PUBLISHED_TAG_LEN))
     publisher_last_updated_epoch_ms = Column(BigInteger)
 
@@ -135,10 +162,12 @@ class TableSource(Base):
     """
     __tablename__ = 'table_source'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     source = Column(String(URL_LEN), nullable=False)
     source_type = Column(String(32), nullable=False)
-    table_rk = Column(String(KEY_LEN), ForeignKey('table_metadata.rk', ondelete='cascade'), nullable=False)
+    table_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                      ForeignKey('table_metadata.rk', ondelete='cascade'),
+                      nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
 
@@ -149,11 +178,13 @@ class TableTimestamp(Base):
     """
     __tablename__ = 'table_timestamp'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     last_updated_timestamp = Column(Integer, nullable=False)
     timestamp = Column(Integer, nullable=False)
     name = Column(String(NAME_LEN), nullable=False)
-    table_rk = Column(String(KEY_LEN), ForeignKey('table_metadata.rk', ondelete='cascade'), nullable=False)
+    table_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                      ForeignKey('table_metadata.rk', ondelete='cascade'),
+                      nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)
 
@@ -164,10 +195,12 @@ class TableWatermark(Base):
     """
     __tablename__ = 'table_watermark'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     partition_key = Column(String(32), nullable=False)
     partition_value = Column(String(32), nullable=False)
     create_time = Column(String(32), nullable=False)
-    table_rk = Column(String(KEY_LEN), ForeignKey('table_metadata.rk', ondelete='cascade'), nullable=False)
+    table_rk = Column(String(KEY_LEN, **INDEX_KEY_COLLATION_ARGS),
+                      ForeignKey('table_metadata.rk', ondelete='cascade'),
+                      nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)

--- a/amundsen_rds/models/tag.py
+++ b/amundsen_rds/models/tag.py
@@ -3,7 +3,9 @@
 
 from sqlalchemy import BigInteger, Column, String
 
-from amundsen_rds.models.base import KEY_LEN, PUBLISHED_TAG_LEN, Base
+from amundsen_rds.models.base import (
+    INDEX_KEY_COLLATION_ARGS, PUBLISHED_TAG_LEN, Base
+)
 
 
 class Tag(Base):
@@ -12,7 +14,7 @@ class Tag(Base):
     """
     __tablename__ = 'tag'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(128, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     tag_type = Column(String(32), nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN))
     publisher_last_updated_epoch_ms = Column(BigInteger)

--- a/amundsen_rds/models/updated_timestamp.py
+++ b/amundsen_rds/models/updated_timestamp.py
@@ -3,7 +3,7 @@
 
 from sqlalchemy import BigInteger, Column, Integer, String
 
-from amundsen_rds.models.base import KEY_LEN, PUBLISHED_TAG_LEN, Base
+from amundsen_rds.models.base import PUBLISHED_TAG_LEN, Base
 
 
 class UpdatedTimestamp(Base):
@@ -12,7 +12,7 @@ class UpdatedTimestamp(Base):
     """
     __tablename__ = 'updated_timestamp'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(64), primary_key=True)
     last_timestamp = Column(Integer, nullable=False)
     published_tag = Column(String(PUBLISHED_TAG_LEN), nullable=False)
     publisher_last_updated_epoch_ms = Column(BigInteger, nullable=False)

--- a/amundsen_rds/models/user.py
+++ b/amundsen_rds/models/user.py
@@ -4,7 +4,9 @@
 from sqlalchemy import BigInteger, Boolean, Column, Integer, String
 from sqlalchemy.orm import relationship
 
-from amundsen_rds.models.base import KEY_LEN, PUBLISHED_TAG_LEN, Base
+from amundsen_rds.models.base import (
+    INDEX_KEY_COLLATION_ARGS, KEY_LEN, PUBLISHED_TAG_LEN, Base
+)
 
 
 class User(Base):
@@ -13,7 +15,7 @@ class User(Base):
     """
     __tablename__ = 'users'
 
-    rk = Column(String(KEY_LEN), primary_key=True)
+    rk = Column(String(320, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     email = Column(String(320), nullable=False)
     is_active = Column(Boolean)
     first_name = Column(String(64))


### PR DESCRIPTION
Increase key/name length to support longer identifiers name in more data sources. Also, in order to support MySQL backend, specify the collation as latin-1 (in Base.py INDEX_KEY_COLLATION_ARGS) for primary key columns to handle the index key size limit.