### PR TITLE
feat: Adding profile_url field to user model

### DIFF
--- a/amundsen_rds/migrations/versions/a539c998cc1e_add_profile_url_column_to_users_table.py
+++ b/amundsen_rds/migrations/versions/a539c998cc1e_add_profile_url_column_to_users_table.py
@@ -1,0 +1,24 @@
+"""add profile url column to users table
+
+Revision ID: a539c998cc1e
+Revises: c194a2dc1240
+Create Date: 2021-10-06 18:46:25.149618
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a539c998cc1e'
+down_revision = 'c194a2dc1240'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('users', sa.Column('profile_url', sa.String(length=320), nullable=True))
+
+
+def downgrade():
+    op.drop_column('users', 'profile_url')

--- a/amundsen_rds/models/user.py
+++ b/amundsen_rds/models/user.py
@@ -18,6 +18,7 @@ class User(Base):
     rk = Column(String(320, **INDEX_KEY_COLLATION_ARGS), primary_key=True)
     email = Column(String(320), nullable=False)
     is_active = Column(Boolean)
+    profile_url = Column(String(320))
     first_name = Column(String(64))
     last_name = Column(String(64))
     full_name = Column(String(256))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import find_packages, setup
 
-__version__ = '0.0.5'
+__version__ = '0.0.6'
 
 
 requirements = [


### PR DESCRIPTION
Signed-off-by: Kristen Armes <karmes@lyft.com>

### Summary of Changes

This change adds the `profile_url` field to the user model. As of today, the `profile_url` field already exists in the frontend and common user models. This change is in preparation for a change I'm making to add `profile_url` to the databuilder user model as well. My use case requires the field for use with neo4j, but I am adding it here for consistency so that I would be able to update the `get_user_record` function to set the `profile_url` in the databuilder user model as well.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes.
